### PR TITLE
Add supports for dot in variable name and custom functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,21 @@ A variable is just a word inside your formula like this :
 Just before executing a formula, make sure to inject all the required variables in an array
 
 ```
-$variables = array(
+$variables = [
    'price' => 40.2,
    'rate' => 12.8
-);
+];
+
+$executable->run($variables);
+```
+
+Variables now supports dot `.` as the name.
+
+```php
+$variables = [
+   'user.name' => 'John Doe'
+   'user.age' => '23'
+];
 
 $executable->run($variables);
 ```
@@ -84,6 +95,23 @@ You can embed functions as much as you like
 
 ```php
    'pow(sqrt(4), 2)'
+```
+
+## Custom functions
+
+Now function can be added before compiling should you want to add more variables.
+
+```php
+$compiler = new Compiler();
+$compiler->registerFunction('foobar', function ($a, $b) {
+    return $a + $b;
+});
+$executable = $compiler->compile("foobar(foo, bar)");
+$params = [
+    'foo' => 1,
+    'bar' => 2
+];
+$executable->run($params);
 ```
 
 # Listing parameters

--- a/src/FormulaInterpreter/Compiler.php
+++ b/src/FormulaInterpreter/Compiler.php
@@ -60,6 +60,11 @@ class Compiler
             return $a % $b;
         });
     }
+
+    public function registerFunction($name, callable $callable)
+    {
+        $this->functionCommandFactory->registerFunction($name, $callable);
+    }
     
     /**
      * Compile an expression and return the corresponding executable

--- a/src/FormulaInterpreter/Parser/VariableParser.php
+++ b/src/FormulaInterpreter/Parser/VariableParser.php
@@ -18,7 +18,7 @@ class VariableParser implements ParserInterface
     {
         $expression = trim($expression);
         
-        if (!preg_match('/^([a-zA-Z_]+[0-9]*)+$/', $expression)) {
+        if (!preg_match('/^([a-zA-Z_]+[0-9\.]*)+$/', $expression)) {
             throw new ParserException($expression);
         }
         

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -90,4 +90,40 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             ['foo.bar * bar.foo', ['foo.bar', 'bar.foo']],
         ];
     }
+
+    /**
+     * @dataProvider getCompileRegisterFunctionsData
+     */
+    public function testCompileRegisterFunctions($expression, $result, $variables = [], $functions = [])
+    {
+        $compiler = new Compiler();
+
+        foreach ($functions as $name => $callable) {
+            $compiler->registerFunction($name, $callable);
+        }
+
+        $executable = $compiler->compile($expression);
+        $this->assertEquals($executable->run($variables), $result);
+    }
+
+    public function getCompileRegisterFunctionsData()
+    {
+        return [
+            ['max(foo.bar, bar.foo)', 3, ['foo.bar' => 3, 'bar.foo' => 2], ['max' => 'max']],
+            ['foobar(foo.bar, bar.foo)', 6, ['foo.bar' => 3, 'bar.foo' => 2], [
+                'foobar' => function($a, $b) {
+                    return $a * $b;
+                }
+            ]],
+            ['foobar1(foobar2(foo.bar), bar.foo)', 12, ['foo.bar' => 3, 'bar.foo' => 2], [
+                'foobar1' => function($a, $b) {
+                    return $a * $b;
+                },
+                'foobar2' => function($a) {
+                    return $a * 2;
+                }
+            ]],
+        ];
+
+    }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -51,6 +51,9 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             // Issue 8
             ['pow(foo,bar)', 9, ['foo' => 3, 'bar' => 2]],
             ['pow(foo, bar)', 9, ['foo' => 3, 'bar' => 2]],
+
+            // Support dot
+            ['pow(foo.bar, bar.foo)', 9, ['foo.bar' => 3, 'bar.foo' => 2]],
         ];
     }
 
@@ -84,6 +87,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             ['foo * bar', ['foo', 'bar']],
             ['pow(foo, bar)', ['foo', 'bar']],
             ['pow(sqrt(pow(foo, bar)), baz)', ['foo', 'bar', 'baz']],
+            ['foo.bar * bar.foo', ['foo.bar', 'bar.foo']],
         ];
     }
 }

--- a/tests/Parser/VariableParserTest.php
+++ b/tests/Parser/VariableParserTest.php
@@ -40,6 +40,7 @@ class VariableParserTest extends \PHPUnit\Framework\TestCase
             ['with_underscore', ['name' => 'with_underscore']],
             ['camelCase', ['name' => 'camelCase']],
             ['rate2', ['name' => 'rate2']],
+            ['with.dot', ['name' => 'with.dot']],
         ];
     }
     


### PR DESCRIPTION
This adds support for dot in variable names and custom function from variables.

e.g.
```php
$compiler = new Compiler();
$executable = $compiler->compile("foo.bar + bar.foo");
$params = [
   "foo.bar" => 1,
   "bar.foo" => 2,
];
$executable->run($params);
```


```php
$compiler = new Compiler();
$compiler->registerFunction('foobar', function ($a, $b) {
          return $a + $b;
    });
$executable = $compiler->compile("foobar(1, 2)");
$executable->run($params);
```