### PR TITLE
Add support for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ $variables = [
 $executable->run($variables);
 ```
 
+## String support
+
+Variables can contain string. Use double quote (`"`) for denote a string.
+
+```php
+'a = "Hello world"'
+```
+
 # Using functions
 
 Here is an example of expression using a function :

--- a/src/FormulaInterpreter/Command/CommandFactory/StringCommandFactory.php
+++ b/src/FormulaInterpreter/Command/CommandFactory/StringCommandFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace FormulaInterpreter\Command\CommandFactory;
+
+use FormulaInterpreter\Command\StringCommand;
+
+/**
+ * Description of FunctionParser
+ *
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+class StringCommandFactory implements CommandFactoryInterface
+{
+    public function create($options)
+    {
+        if (!isset($options['value'])) {
+            throw new CommandFactoryException();
+        }
+        
+        return new StringCommand($options['value']);
+    }
+}

--- a/src/FormulaInterpreter/Command/StringCommand.php
+++ b/src/FormulaInterpreter/Command/StringCommand.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+
+namespace FormulaInterpreter\Command;
+
+/**
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+class StringCommand implements CommandInterface
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    public function __construct($value)
+    {
+        if (!is_string($value)) {
+            $message = sprintf(
+                'Parameter $value of method __construct() of class %s must be an string. Got %s type instead.',
+                get_class($this),
+                gettype($value)
+            );
+            throw new \InvalidArgumentException($message);
+        }
+
+        $this->value = $value;
+    }
+
+    public function run()
+    {
+        return $this->value;
+    }
+
+    public static function create($options)
+    {
+    }
+
+    public function getParameters()
+    {
+        return [];
+    }
+}

--- a/src/FormulaInterpreter/Compiler.php
+++ b/src/FormulaInterpreter/Compiler.php
@@ -34,6 +34,7 @@ class Compiler
     {
         $this->parser = new Parser\CompositeParser();
         $this->parser->addParser(new Parser\NumericParser());
+        $this->parser->addParser(new Parser\StringParser());
         $this->parser->addParser(new Parser\VariableParser());
         $this->parser->addParser(new Parser\FunctionParser($this->parser));
         $this->parser->addParser(new Parser\OperatorParser($this->parser));
@@ -41,6 +42,7 @@ class Compiler
         $this->variables = new \ArrayObject();
         
         $this->commandFactory = new Command\CommandFactory();
+        $this->commandFactory->registerFactory('string', new Command\CommandFactory\StringCommandFactory());
         $this->commandFactory->registerFactory('numeric', new Command\CommandFactory\NumericCommandFactory());
         $this->commandFactory->registerFactory('variable', new Command\CommandFactory\VariableCommandFactory($this->variables));
         $this->commandFactory->registerFactory('operation', new Command\CommandFactory\OperationCommandFactory($this->commandFactory));

--- a/src/FormulaInterpreter/Parser/StringParser.php
+++ b/src/FormulaInterpreter/Parser/StringParser.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace FormulaInterpreter\Parser;
+
+/**
+ * Description of FunctionParser
+ *
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+class StringParser implements ParserInterface
+{
+    const PATTERN = '/^".+"$/';
+
+    public function parse($expression)
+    {
+        $expression = trim($expression);
+        
+        if (!preg_match(self::PATTERN, $expression)) {
+            throw new ParserException($expression);
+        }
+
+        $string = substr($expression, 1, strlen($expression) - 2);
+        $string = str_replace("\\\"", "\"", $string);
+        return $infos = [
+            'type' => 'string',
+            'value' => (string) $string,
+        ];
+    }
+}

--- a/tests/Command/CommandFactory/StringCommandFactoryTest.php
+++ b/tests/Command/CommandFactory/StringCommandFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace Tests\FormulaInterpreter\Command\CommandFactory;
+
+use FormulaInterpreter\Command\CommandFactory\CommandFactoryException;
+use FormulaInterpreter\Command\CommandFactory\StringCommandFactory;
+use FormulaInterpreter\Command\NumericCommand;
+use FormulaInterpreter\Command\CommandFactory\NumericCommandFactory;
+use FormulaInterpreter\Command\StringCommand;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Description of NumericCommandFactory
+ *
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+class StringCommandFactoryTest extends TestCase
+{
+    
+    /**
+     *  @dataProvider getData
+     */
+    public function testCreate($value)
+    {
+        $factory = new StringCommandFactory();
+        $options = ['value' => $value];
+        $this->assertEquals($factory->create($options), new StringCommand($value));
+    }
+    
+    public function getData()
+    {
+        return [
+            ['2'],
+            ['4'],
+        ];
+    }
+    
+    public function testCreateWithMissingValueOption()
+    {
+        $this->expectException(CommandFactoryException::class);
+        $factory = new StringCommandFactory();
+        $factory->create([]);
+    }
+}

--- a/tests/Command/StringCommandTest.php
+++ b/tests/Command/StringCommandTest.php
@@ -31,6 +31,17 @@ class StringCommandTest extends TestCase
             ["2.2", "2.2"],
         ];
     }
+
+    public function testGetParameters()
+    {
+        $command = new StringCommand("\"Hello\"");
+        $this->assertEmpty($command->getParameters());
+    }
+
+    public function testCreate()
+    {
+        $this->assertNull(StringCommand::create([]));
+    }
     
     /**
      * @dataProvider getIncorrectValues

--- a/tests/Command/StringCommandTest.php
+++ b/tests/Command/StringCommandTest.php
@@ -1,21 +1,17 @@
 <?php
-
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * @author Petra Barus <petra.barus@gmail.com>
  */
 
 namespace Tests\FormulaInterpreter\Command;
 
-use FormulaInterpreter\Command\NumericCommand;
+use FormulaInterpreter\Command\StringCommand;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Description of ParserTest
- *
- * @author mathieu
+ * @author Petra Barus <petra.barus@gmail.com>
  */
-class NumericCommandTest extends TestCase
+class StringCommandTest extends TestCase
 {
     
     /**
@@ -23,7 +19,7 @@ class NumericCommandTest extends TestCase
      */
     public function testRun($value, $result)
     {
-        $command = new NumericCommand($value);
+        $command = new StringCommand($value);
         
         $this->assertEquals($command->run(), $result);
     }
@@ -31,8 +27,8 @@ class NumericCommandTest extends TestCase
     public function getData()
     {
         return [
-            [2, 2],
-            [2.2, 2.2],
+            ["2", "2"],
+            ["2.2", "2.2"],
         ];
     }
     
@@ -42,14 +38,14 @@ class NumericCommandTest extends TestCase
     public function testInjectIncorrectValue($value)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $command = new NumericCommand($value);
+        $command = new StringCommand($value);
         $command->run();
     }
 
     public function getIncorrectValues()
     {
         return [
-            ['string'],
+            [new \stdClass()],
             [false],
             [[]],
         ];

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -74,6 +74,10 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             ['(3 = 3) AND (4 < 1)', false],
             ['(3 = 3) OR (4 < 1)', true],
             ['(3 < 3) OR (4 < 1)', false],
+
+            //Support string
+            ['a = "Hello"', true, ['a' => "Hello"]],
+            ['a = "Hello"', false, ['a' => "World"]],
         ];
     }
 

--- a/tests/Parser/StringParserTest.php
+++ b/tests/Parser/StringParserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace Tests\FormulaInterpreter\Parser;
+
+use FormulaInterpreter\Parser\NumericParser;
+use FormulaInterpreter\Parser\ParserException;
+use FormulaInterpreter\Parser\StringParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Description of StringParserTest
+ *
+ * @author Petra Barus <petra.barus@gmail.com>
+ */
+class StringParserTest extends TestCase
+{
+    /**
+     * @var StringParser
+     */
+    private $parser;
+
+    public function setUp()
+    {
+        $this->parser = new StringParser();
+    }
+    
+    /**
+     * @dataProvider getStringValue
+     */
+    public function testParseInteger($expression, $infos)
+    {
+        $infos['type'] = 'string';
+        $this->assertEquals($infos, $this->parser->parse($expression));
+    }
+    
+    public function getStringValue()
+    {
+        return [
+            ['"Hello"', ['value' => "Hello"]],
+            ['"Hello, World!"', ['value' => "Hello, World!"]],
+            ['"Hello, \"World!\""', ['value' => 'Hello, "World!"']],
+        ];
+    }
+    
+    /**
+     * @dataProvider getUncorrectExpressionData
+     */
+    public function testParseUncorrectExpression($expression)
+    {
+        $this->expectException(ParserException::class);
+        $this->parser->parse($expression);
+    }
+    
+    public function getUncorrectExpressionData()
+    {
+        return [
+            ['mlksdf'],
+            ['MLKmlm'],
+            [' MLKmlm '],
+            [' some_function( '],
+            ['2.23.23']
+        ];
+    }
+}


### PR DESCRIPTION
Variables can contain string. Use double quote (`"`) for denote a string.

```php
'a = "Hello world"'
```